### PR TITLE
Add TreeSitterParserBase for tree-sitter language parsers

### DIFF
--- a/vanir/language_parsers/tree_sitter_base.py
+++ b/vanir/language_parsers/tree_sitter_base.py
@@ -1,0 +1,256 @@
+# Copyright 2025 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+"""Shared base class for tree-sitter-backed Vanir language parsers.
+
+This module does NOT import tree-sitter at module level.  Subclasses guard
+their own tree-sitter imports with try/except ImportError so that the module
+can be imported on Python 3.9 (where tree-sitter is not installed) without
+raising an error.
+
+Inheritance chain:
+    AbstractLanguageParser  (existing ABC — unchanged)
+        └── TreeSitterParserBase  (this module)
+                └── PythonParser  (thin subclass)
+                └── GoParser      (future)
+"""
+
+import abc
+from typing import Optional, Sequence, Tuple
+
+from vanir.language_parsers import abstract_language_parser
+from vanir.language_parsers import common
+
+
+# ---------------------------------------------------------------------------
+# Iterative cursor utilities  (no tree-sitter import needed — callers pass nodes)
+# ---------------------------------------------------------------------------
+
+def _collect_tokens_cursor(node, skip_types, string_type, out_dict):
+    """Iterative TreeCursor DFS — populates out_dict[line_number, list[str]].
+
+    - Nodes in skip_types are skipped (their whole subtree is pruned).
+    - Nodes of string_type are emitted as a single opaque token.
+    - Leaf nodes (no children) are emitted as individual tokens.
+    - All other nodes are descended into.
+
+    out_dict: dict[int, list[str]]  key = 1-indexed line number.
+    """
+    cursor = node.walk()
+    while True:
+        n = cursor.node
+        ntype = n.type
+        if ntype in skip_types:
+            pass  # prune subtree — fall through to sibling/parent nav
+        elif ntype == string_type or not n.children:
+            line = n.start_point[0] + 1
+            out_dict.setdefault(line, []).append(
+                n.text.decode('utf-8', errors='replace'))
+        elif cursor.goto_first_child():
+            continue  # descended — restart loop from new position
+        # Sibling / parent navigation
+        while not cursor.goto_next_sibling():
+            if not cursor.goto_parent():
+                return
+
+
+def _flat_tokens_cursor(node, skip_types, string_type):
+    """Return a flat ordered list of token strings from node's subtree."""
+    buf = {}
+    _collect_tokens_cursor(node, skip_types, string_type, buf)
+    return [tok for line in sorted(buf) for tok in buf[line]]
+
+
+def _collect_errors_cursor(root):
+    """Iterative TreeCursor walk that collects ERROR nodes.
+
+    Returns a list of common.ParseError, one per ERROR node encountered.
+    The walk visits every node (ERROR nodes are not pruned) so that
+    errors inside partially-parsed subtrees are also reported.
+    """
+    errors = []
+    cursor = root.walk()
+    while True:
+        n = cursor.node
+        if n.type == 'ERROR':
+            line = n.start_point[0] + 1
+            col = n.start_point[1]
+            bad_token = n.text.decode('utf-8', errors='replace')
+            display = bad_token[:80] + ('...' if len(bad_token) > 80 else '')
+            errors.append(common.ParseError(
+                line=line,
+                column=col,
+                bad_token=display,
+                message='syntax error',
+            ))
+        # Always try to descend — errors inside ERROR subtrees are also reported.
+        if cursor.goto_first_child():
+            continue
+        while not cursor.goto_next_sibling():
+            if not cursor.goto_parent():
+                return errors
+
+
+def _overlaps(func_start, func_end, ranges):
+    """Return True if [func_start, func_end] overlaps any (start, end) range.
+
+    An empty ranges list means "no filter — include all functions".
+    """
+    if not ranges:
+        return True
+    return any(func_start <= r_end and func_end >= r_start
+               for r_start, r_end in ranges)
+
+
+# ---------------------------------------------------------------------------
+# TreeSitterParserBase
+# ---------------------------------------------------------------------------
+
+class TreeSitterParserBase(abstract_language_parser.AbstractLanguageParser):
+    """Shared base for tree-sitter-backed Vanir language parsers.
+
+    Subclasses must set the following class attributes and implement the
+    three abstract methods below.
+    """
+
+    # Subclasses set these at class level.
+    LANGUAGE = None          # tree_sitter.Language instance, or None if unavailable
+    _FUNC_QUERY = None       # compiled Query for function discovery
+    SKIP_TOKEN_TYPES = frozenset()
+    STRING_NODE_TYPE = 'string'
+
+    def __init__(self, filename: str):
+        # Lazy import so the module itself has no tree-sitter dependency at
+        # import time.
+        from tree_sitter import Parser  # pylint: disable=import-outside-toplevel
+        with open(filename, 'rb') as f:
+            self._source = f.read()
+        self._tree = Parser(self.LANGUAGE).parse(self._source)
+        if self._tree is None:
+            raise RuntimeError(
+                f'tree-sitter failed to parse {filename!r}')
+
+    def get_chunks(
+        self,
+        affected_line_ranges_for_functions: Optional[
+            Sequence[Tuple[int, int]]
+        ] = None,
+    ) -> common.ParseResults:
+        from tree_sitter import QueryCursor  # pylint: disable=import-outside-toplevel
+
+        if affected_line_ranges_for_functions is None:
+            affected_line_ranges_for_functions = []
+
+        root = self._tree.root_node
+
+        # --- Step 1: function discovery via C-level Query ---
+        all_matches = list(QueryCursor(self._FUNC_QUERY).matches(root))
+        all_func_nodes = [m['func.def'][0] for _, m in all_matches]
+        all_name_nodes = [m['func.name'][0] for _, m in all_matches]
+
+        # --- Step 2: build one FunctionChunkBase per matched function ---
+        function_chunks = []
+        for i, func_node in enumerate(all_func_nodes):
+            start_line = func_node.start_point[0] + 1
+            end_line = func_node.end_point[0] + 1
+
+            if not _overlaps(start_line, end_line,
+                             affected_line_ranges_for_functions):
+                continue
+
+            name_node = all_name_nodes[i] if i < len(all_name_nodes) else None
+            name = (name_node.text.decode('utf-8', errors='replace')
+                    if name_node else '')
+
+            params_node = func_node.child_by_field_name('parameters')
+            parameters = (self._extract_param_names(params_node)
+                          if params_node else [])
+
+            return_types, used_data_types = self._extract_annotations(func_node)
+
+            # Byte ranges of functions nested directly inside this function
+            # (used by _collect_locals_calls to exclude their captures).
+            nested_ranges = [
+                (n.start_byte, n.end_byte)
+                for n in all_func_nodes
+                if (n.start_byte > func_node.start_byte
+                    and n.end_byte <= func_node.end_byte)
+            ]
+
+            local_vars_set: set = set()
+            called_fns_set: set = set()
+            body_node = func_node.child_by_field_name('body')
+            if body_node:
+                local_vars_set, called_fns_set = self._collect_locals_calls(
+                    body_node, nested_ranges)
+            local_vars_set -= set(parameters)
+
+            tokens = _flat_tokens_cursor(
+                func_node, self.SKIP_TOKEN_TYPES, self.STRING_NODE_TYPE)
+
+            function_chunks.append(common.FunctionChunkBase(
+                name=name,
+                return_types=return_types,
+                parameters=parameters,
+                used_data_types=used_data_types,
+                local_variables=sorted(local_vars_set),
+                called_functions=sorted(called_fns_set),
+                tokens=tokens,
+            ))
+
+        # --- Step 3: line chunk (whole-file token collection) ---
+        tokens_by_line: dict = {}
+        _collect_tokens_cursor(
+            root, self.SKIP_TOKEN_TYPES, self.STRING_NODE_TYPE, tokens_by_line)
+        line_chunk = common.LineChunkBase(tokens=tokens_by_line)
+
+        # --- Step 4: parse errors ---
+        parse_errors = _collect_errors_cursor(root)
+
+        return common.ParseResults(
+            function_chunks=function_chunks,
+            line_chunk=line_chunk,
+            parse_errors=parse_errors,
+        )
+
+    # --- Abstract methods (language-specific) ---
+
+    @abc.abstractmethod
+    def _extract_param_names(self, params_node) -> list:
+        """Extract parameter names from a parameters node.
+
+        Args:
+          params_node: The tree-sitter node for the parameter list.
+
+        Returns:
+          List of parameter name strings (in order).
+        """
+
+    @abc.abstractmethod
+    def _extract_annotations(self, func_node) -> tuple:
+        """Extract type annotations from a function definition node.
+
+        Args:
+          func_node: The tree-sitter function_definition node.
+
+        Returns:
+          (return_types, used_data_types) where:
+            return_types    — [] or [[token, ...]] (at most one return annotation).
+            used_data_types — [[token, ...], ...]  (one list per param annotation).
+        """
+
+    @abc.abstractmethod
+    def _collect_locals_calls(self, body_node, nested_ranges) -> tuple:
+        """Collect local variable names and called function names from a body.
+
+        Args:
+          body_node: The tree-sitter node for the function body.
+          nested_ranges: List of (start_byte, end_byte) pairs for nested
+            function definitions that should be excluded from the search.
+
+        Returns:
+          (local_vars, called_fns) — both are sets of strings.
+        """


### PR DESCRIPTION
## Summary

Adds `TreeSitterParserBase`, a shared abstract base class that sits between `AbstractLanguageParser` and any future tree-sitter-backed language parser. This PR introduces the infrastructure layer only, no language-specific logic is included. The first concrete subclass (`PythonParser`) follows in a separate PR.

## Objective

Vanir's parser pipeline expects every language parser to produce a `ParseResults` object containing:

- **`function_chunks`** - one `FunctionChunkBase` per function, carrying its name, parameters, return types, used data types, local variables, called functions, and raw tokens
- **`line_chunk`** - a `LineChunkBase` with all file tokens grouped by line number, used for line-based signature matching
- **`parse_errors`** - a list of `ParseError` for any syntax errors encountered

Existing parsers (C/C++, Java) fulfill this contract via ANTLR4 grammars. This PR fulfills the same contract using **tree-sitter**, enabling faster parser development for new languages with no grammar compilation step.

## Implementation

### `tree_sitter_base.py`

#### `TreeSitterParserBase` (class)

The core class. Subclasses set three class-level attributes:

- `LANGUAGE` - a `tree_sitter.Language` instance for the target language
- `_FUNC_QUERY` - a compiled tree-sitter `Query` for matching function definitions
- `SKIP_TOKEN_TYPES` - a `frozenset` of node types to exclude from token collection (e.g. comments)
- `STRING_NODE_TYPE` - the node type to treat as an opaque string token (default: `'string'`)

#### `__init__(filename)`

- Reads the source file as bytes
- Instantiates a tree-sitter `Parser` with the subclass's `LANGUAGE`
- Parses the file into a concrete syntax tree (`self._tree`)
- Tree-sitter elements used: `Parser`, `tree_sitter.Language`

#### `get_chunks(affected_line_ranges_for_functions)`, main pipeline

Implements the full `ParseResults` assembly in four steps:

**Step 1, Function discovery**
- Runs `_FUNC_QUERY` against the root node using `QueryCursor`
- Extracts `func.def` and `func.name` capture groups from each match
- Tree-sitter elements used: `QueryCursor`, `Query.matches()`, named captures

**Step 2, FunctionChunkBase construction**
- For each matched function node, computes start/end line numbers from `start_point` / `end_point`
- Filters by `affected_line_ranges_for_functions` using `_overlaps()`
- Extracts function name from the `func.name` capture node
- Retrieves the `parameters` child field via `child_by_field_name('parameters')`
- Delegates to three abstract methods (see below) for language-specific extraction
- Identifies nested function byte ranges to exclude from local/call collection
- Collects flat token list via `_flat_tokens_cursor()`

**Step 3, LineChunkBase construction**
- Runs `_collect_tokens_cursor()` over the entire root node
- Produces a `dict[int, list[str]]` mapping line numbers to token lists
- Passed directly into `LineChunkBase`

**Step 4, Parse error collection**
- Runs `_collect_errors_cursor()` to find all `ERROR` nodes in the tree
- Each ERROR node becomes a `ParseError` with line, column, and token preview

### Cursor utility functions

#### `_collect_tokens_cursor(node, skip_types, string_type, out_dict)`
- Iterative DFS using tree-sitter's `TreeCursor` (avoids Python recursion limits)
- Prunes subtrees whose root type is in `skip_types` (e.g. comments, decorators)
- Emits nodes of `string_type` as a single opaque token
- Emits all other leaf nodes (no children) as individual tokens
- Populates `out_dict[line_number] → [token, ...]`
- Tree-sitter elements used: `node.walk()`, `TreeCursor.goto_first_child()`, `goto_next_sibling()`, `goto_parent()`, `node.text`, `node.start_point`

#### `_flat_tokens_cursor(node, skip_types, string_type)`
- Thin wrapper over `_collect_tokens_cursor()`
- Returns a flat ordered list of token strings (sorted by line, then order within line)

#### `_collect_errors_cursor(root)`
- Iterative DFS that visits every node without pruning
- Collects all `ERROR` nodes and returns them as `ParseError` objects
- Truncates bad token display to 80 characters
- Tree-sitter elements used: `node.type == 'ERROR'`, `node.start_point`, `node.text`

#### `_overlaps(func_start, func_end, ranges)`
- Pure utility, returns `True` if a function's line range overlaps any of the provided affected line ranges
- Empty `ranges` means no filter (include all functions)

### Abstract methods (subclasses must implement)

#### `_extract_param_names(params_node) → list[str]`
Extracts ordered parameter name strings from a tree-sitter `parameters` node. Subclasses traverse the parameter node's children according to the language's grammar (e.g. `identifier`, `typed_parameter`, `default_parameter`).

#### `_extract_annotations(func_node) → (return_types, used_data_types)`
Extracts type annotation information from a function definition node:
- `return_types` - list of token lists from the return type annotation (empty if none)
- `used_data_types` - list of token lists, one per annotated parameter

#### `_collect_locals_calls(body_node, nested_ranges) → (local_vars, called_fns)`
Walks the function body node to collect:
- `local_vars` - set of locally assigned variable names
- `called_fns` - set of called function names
- `nested_ranges` - byte ranges of nested functions to exclude from collection, preventing inner-scope variables from leaking into the outer function's signature

## Design decisions

- **No module-level tree-sitter import**, the base class is importable on Python 3.9 (where tree-sitter is not installed) without error. All tree-sitter imports are lazy, inside methods.
- **Iterative cursor DFS**, avoids Python's default recursion limit on deeply nested ASTs. All three traversal utilities use `TreeCursor` instead of recursive calls.
- **Language-agnostic**, zero Python-specific logic in this file. All language grammar knowledge lives in concrete subclasses.

## Dependencies

This PR is independent and can be merged alongside:
- `feat/python-parser-deps`
- `feat/python-parser-build`
- `bug/fix-subclass-discovery`

It must be merged **before** `feat/python-parser`.