### PR TITLE
Fix subclass discovery to support multi-level parser hierarchies

### DIFF
--- a/vanir/language_parsers/language_parsers.py
+++ b/vanir/language_parsers/language_parsers.py
@@ -28,9 +28,19 @@ from vanir.language_parsers.java import java_parser
 _P = TypeVar('_P', bound=abstract_language_parser.AbstractLanguageParser)
 
 
+def _all_subclasses(cls):
+  """Recursively collect all concrete (non-abstract) subclasses of cls."""
+  result = []
+  for sub in cls.__subclasses__():
+    if not sub.__abstractmethods__:
+      result.append(sub)
+    result.extend(_all_subclasses(sub))
+  return result
+
+
 def get_parser_class(filename: str) -> Optional[Type[_P]]:
   """Returns the language parser class that handles the given file, or None."""
-  parsers = abstract_language_parser.AbstractLanguageParser.__subclasses__()
+  parsers = _all_subclasses(abstract_language_parser.AbstractLanguageParser)
   ext = os.path.splitext(filename)[1]
   for parser_class in parsers:
     if ext in parser_class.get_supported_extensions():


### PR DESCRIPTION
## Summary

Fixes a bug in `get_parser_class()` where parsers registered two or more levels deep in the `AbstractLanguageParser` hierarchy were silently ignored, causing Vanir to fail to detect a matching parser even when one was available.

## Problem

`get_parser_class()` used `AbstractLanguageParser.__subclasses__()` to discover registered parsers. Python's `__subclasses__()` only returns **direct** subclasses, it does not recurse into grandchildren or deeper.

The existing C++ and Java parsers subclass `AbstractLanguageParser` directly so this was never an issue. However, tree-sitter-backed parsers introduce an intermediate base class:

```
AbstractLanguageParser
    └── TreeSitterParserBase    (intermediate base, not a concrete parser)
            └── PythonParser    (concrete parser, was invisible to subclasses())
```

`PythonParser` would never be returned by `__subclasses__()`, so any `.py` file passed to `get_parser_class()` would return `None` and raise `NotImplementedError`.

## Fix

Replaces the single `__subclasses__()` call with a recursive helper `_all_subclasses(cls)` that walks the full subclass tree and returns only concrete (non-abstract) classes:

```python
def _all_subclasses(cls):
    result = []
    for sub in cls.__subclasses__():
        if not sub.__abstractmethods__:
            result.append(sub)
        result.extend(_all_subclasses(sub))
    return result
```

- Abstract intermediate classes (e.g. `TreeSitterParserBase`) are excluded via the `__abstractmethods__` check
- All concrete leaf parsers at any depth are included
- Existing C++ and Java parser behaviour is completely unchanged

## Dependencies

This PR is independent and can be merged in any order alongside other PRs in this series. It must be merged before `feat/python-parser`.