### PR TITLE
Add tree-sitter dependencies for Python parser

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,4 +14,8 @@ google-api-core
 google-cloud-iam
 protobuf
 jsonpath_ng
+# tree-sitter and the Python grammar require Python >= 3.10.
+# On Python 3.9, the PythonParser is unavailable and .py files are skipped.
+tree-sitter>=0.21.0; python_version>='3.10'
+tree-sitter-python>=0.21.0; python_version>='3.10'
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,6 +16,6 @@ protobuf
 jsonpath_ng
 # tree-sitter and the Python grammar require Python >= 3.10.
 # On Python 3.9, the PythonParser is unavailable and .py files are skipped.
-tree-sitter>=0.21.0; python_version>='3.10'
-tree-sitter-python>=0.21.0; python_version>='3.10'
+tree-sitter>=0.21.0,<0.26; python_version>='3.10'
+tree-sitter-python>=0.21.0,<0.26; python_version>='3.10'
 


### PR DESCRIPTION
## Summary

Adds `tree-sitter` and `tree-sitter-python` to Vanir's `requirements.txt` to enable the Python language parser.

---

## Objective

The `PythonParser` implementation depends on two pip packages:

- `tree-sitter` — core tree-sitter Python bindings
- `tree-sitter-python` — compiled Python grammar for tree-sitter

Both packages are guarded with `python_version>='3.10'` so they are never installed on Python 3.9, where `PythonParser` is intentionally unavailable and `.py` files are silently skipped.

---

## Changes

### `requirements/requirements.txt`

Two new entries added at the bottom:

```text
# tree-sitter and the Python grammar require Python >= 3.10.
# On Python 3.9, the PythonParser is unavailable and .py files are skipped.
tree-sitter>=0.21.0; python_version>='3.10'
tree-sitter-python>=0.21.0; python_version>='3.10'
```

---

## Note for maintainers

Lock files (`requirements_lock_3.10.txt` through `requirements_lock_3.13.txt`) need to be regenerated after merge using:

```bash
bazel run //requirements:requirements_3.10.update
bazel run //requirements:requirements_3.11.update
bazel run //requirements:requirements_3.12.update
bazel run //requirements:requirements_3.13.update
```

---

## Dependencies

This PR is independent and can be merged in any order alongside:

- `feat/tree-sitter-integration`
- `feat/python-parser-build`
- `bug/fix-subclass-discovery`

Must be merged before `feat/python-parser`.